### PR TITLE
add rubocop-legion plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ jobs:
   ci:
     uses: LegionIO/.github/.github/workflows/ci.yml@main
 
-  lint:
-    uses: LegionIO/.github/.github/workflows/lint-patterns.yml@main
+  excluded-files:
+    uses: LegionIO/.github/.github/workflows/excluded-files.yml@main
 
   security:
     uses: LegionIO/.github/.github/workflows/security-scan.yml@main
@@ -27,7 +27,7 @@ jobs:
     uses: LegionIO/.github/.github/workflows/stale.yml@main
 
   release:
-    needs: [ci, lint]
+    needs: [ci, excluded-files]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     uses: LegionIO/.github/.github/workflows/release.yml@main
     secrets:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,36 +1,6 @@
-AllCops:
-  TargetRubyVersion: 3.4
-  NewCops: enable
-  SuggestExtensions: false
+inherit_gem:
+  rubocop-legion: config/lex.yml
 
-Layout/LineLength:
-  Max: 160
-
-Metrics/MethodLength:
-  Max: 30
-
-Metrics/AbcSize:
-  Max: 60
-
-Metrics/ClassLength:
-  Max: 300
-
-Metrics/ModuleLength:
-  Max: 500
-
-Metrics/CyclomaticComplexity:
-  Max: 10
-
-Metrics/BlockLength:
-  Exclude:
-    - 'spec/**/*'
-
-Layout/HashAlignment:
-  EnforcedColonStyle: table
-  EnforcedHashRocketStyle: table
-
-Naming/PredicateMethod:
-  Enabled: false
-
-Style/Documentation:
+# code_review.rb has many private helper methods that return non-hash values by design
+Legion/Extension/RunnerReturnHash:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [0.3.13] - 2026-03-30
+
+### Changed
+- update to rubocop-legion 0.1.7, resolve all offenses
+
 ## [0.3.12] - 2026-03-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [0.3.12] - 2026-03-29
+
+### Changed
+- `review_generated` now accepts `**extra` splat for task system payload compatibility; `context:` is optional (default `{}`)
+- Verdict values are now strings (`'approve'`, `'reject'`, `'revise'`) instead of symbols for conditioner matching
+- `build_result` passes `code`, `spec_code`, and extra kwargs through to the result hash for downstream consumers
+- `CodeReviewSubscriber` actor enables `check_subtask?` for task system integration
+
 ## [0.3.11] - 2026-03-29
 
 ### Added

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 group :development do
   gem 'rspec', '~> 3.0'
   gem 'rubocop', '~> 1.0'
+  gem 'rubocop-legion', '~> 0.1'
   gem 'sequel', '~> 5.0'
   gem 'sqlite3'
 end

--- a/lib/legion/extensions/eval.rb
+++ b/lib/legion/extensions/eval.rb
@@ -22,7 +22,7 @@ if defined?(Legion::Transport::Exchange)
   require_relative 'eval/transport/messages/code_review_completed'
 end
 
-require_relative 'eval/actors/code_review_subscriber' if defined?(Legion::Extensions::Actors::Subscription)
+require_relative 'eval/actors/code_review_subscriber'
 
 module Legion
   module Extensions

--- a/lib/legion/extensions/eval/actors/code_review_subscriber.rb
+++ b/lib/legion/extensions/eval/actors/code_review_subscriber.rb
@@ -11,6 +11,7 @@ module Legion
 
           def runner_class = self.class
           def runner_function = 'action'
+          def check_subtask? = true
 
           def action(payload)
             code = payload[:runner_code] || payload[:code]
@@ -30,7 +31,7 @@ module Legion
             result
           rescue StandardError => e
             log.warn("CodeReviewSubscriber failed: #{e.message}")
-            { passed: false, verdict: :reject, error: e.message }
+            { passed: false, verdict: 'reject', error: e.message }
           end
 
           private

--- a/lib/legion/extensions/eval/actors/code_review_subscriber.rb
+++ b/lib/legion/extensions/eval/actors/code_review_subscriber.rb
@@ -37,11 +37,7 @@ module Legion
           private
 
           def log
-            return Legion::Logging if defined?(Legion::Logging)
-
-            @log ||= Object.new.tap do |nl|
-              %i[debug info warn error fatal].each { |m| nl.define_singleton_method(m) { |*| nil } }
-            end
+            Legion::Logging
           end
         end
       end

--- a/lib/legion/extensions/eval/actors/online.rb
+++ b/lib/legion/extensions/eval/actors/online.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'legion/extensions/actors/subscription' unless defined?(Legion::Extensions::Actors::Subscription)
+require 'legion/extensions/actors/subscription'
 
 module Legion
   module Extensions
@@ -30,12 +30,12 @@ module Legion
             false
           end
 
-          def enabled?
-            return false unless defined?(Legion::Transport)
+          def enabled? # rubocop:disable Legion/Extension/ActorEnabledSideEffects
+            return false unless Legion.const_defined?(:Transport, false)
             return false unless defined?(Legion::Extensions::Eval::Runners::Online)
 
             online_enabled?
-          rescue StandardError
+          rescue StandardError => _e
             false
           end
 

--- a/lib/legion/extensions/eval/evaluators/code_evaluator.rb
+++ b/lib/legion/extensions/eval/evaluators/code_evaluator.rb
@@ -31,7 +31,7 @@ module Legion
           def valid_json?(str)
             ::JSON.parse(str)
             true
-          rescue ::JSON::ParserError
+          rescue ::JSON::ParserError => _e
             false
           end
         end

--- a/lib/legion/extensions/eval/evaluators/llm_judge.rb
+++ b/lib/legion/extensions/eval/evaluators/llm_judge.rb
@@ -37,24 +37,24 @@ module Legion
           def evaluate_impl(input:, output:, expected:)
             prompt = render_template(input: input, output: output, expected: expected)
             evaluate_structured(prompt)
-          rescue StandardError
+          rescue StandardError => _e
             evaluate_regex_fallback(prompt)
           end
 
           def evaluate_structured(prompt)
             return evaluate_regex_fallback(prompt) unless structured_available?
 
-            result = Legion::LLM.structured(message: prompt, schema: JUDGE_SCHEMA,
+            result = Legion::LLM.structured(message: prompt, schema: JUDGE_SCHEMA, # rubocop:disable Legion/HelperMigration/DirectLlm
                                             intent: { capability: :reasoning },
                                             caller: { extension: 'lex-eval', operation: 'judge' })
             { score: result[:score], passed: result[:passed],
               explanation: result[:explanation], evidence: result[:evidence] || [] }
-          rescue StandardError
+          rescue StandardError => _e
             evaluate_regex_fallback(prompt)
           end
 
           def evaluate_regex_fallback(prompt)
-            response = Legion::LLM.chat(message: prompt, intent: { capability: :reasoning },
+            response = Legion::LLM.chat(message: prompt, intent: { capability: :reasoning }, # rubocop:disable Legion/HelperMigration/DirectLlm
                                         caller: { extension: 'lex-eval', operation: 'judge' })
             score = extract_score(response.content)
             { score: score, explanation: response.content, passed: score >= threshold, evidence: [] }

--- a/lib/legion/extensions/eval/helpers/guardrails.rb
+++ b/lib/legion/extensions/eval/helpers/guardrails.rb
@@ -79,11 +79,7 @@ module Legion
             end
 
             def log
-              return Legion::Logging if defined?(Legion::Logging)
-
-              @log ||= Object.new.tap do |nl|
-                %i[debug info warn error fatal].each { |m| nl.define_singleton_method(m) { |*| nil } }
-              end
+              Legion::Logging
             end
           end
         end

--- a/lib/legion/extensions/eval/runners/agentic_review.rb
+++ b/lib/legion/extensions/eval/runners/agentic_review.rb
@@ -4,7 +4,7 @@ module Legion
   module Extensions
     module Eval
       module Runners
-        module AgenticReview
+        module AgenticReview # rubocop:disable Legion/Extension/RunnerIncludeHelpers
           REVIEW_SCHEMA = {
             type:       :object,
             properties: {
@@ -23,7 +23,7 @@ module Legion
             required:   %i[confidence recommendation explanation]
           }.freeze
 
-          def review_output(input:, output:, review_prompt: nil, model: nil, provider: nil, **) # rubocop:disable Metrics/ParameterLists
+          def review_output(input:, output:, review_prompt: nil, model: nil, provider: nil, **)
             prompt = build_review_message(review_prompt || default_review_prompt, input, output)
             llm_kwargs = {
               message: prompt, schema: REVIEW_SCHEMA,
@@ -32,14 +32,14 @@ module Legion
             }
             llm_kwargs[:model] = model if model
             llm_kwargs[:provider] = provider if provider
-            Legion::LLM.structured(**llm_kwargs)
+            Legion::LLM.structured(**llm_kwargs) # rubocop:disable Legion/HelperMigration/DirectLlm
           rescue StandardError => e
-            log.warn(e.message) if respond_to?(:log, true)
+            log.warn(e.message) if respond_to?(:log, true) # rubocop:disable Legion/HelperMigration/LoggingGuard
             { confidence: 0.0, recommendation: 'reject',
               issues: [], explanation: "review error: #{e.message}" }
           end
 
-          def review_with_escalation(input:, output:, review_prompt: nil, model: nil, provider: nil, **) # rubocop:disable Metrics/ParameterLists
+          def review_with_escalation(input:, output:, review_prompt: nil, model: nil, provider: nil, **)
             review = review_output(input: input, output: output, review_prompt: review_prompt,
                                    model: model, provider: provider)
             action, priority = determine_escalation(review[:confidence])
@@ -49,7 +49,7 @@ module Legion
             review.merge(action: action, escalated: true, priority: priority)
           end
 
-          def review_experiment(input:, output_a:, output_b:, review_prompt: nil, model: nil, provider: nil, **) # rubocop:disable Metrics/ParameterLists
+          def review_experiment(input:, output_a:, output_b:, review_prompt: nil, model: nil, provider: nil, **)
             review_a = review_output(input: input, output: output_a, review_prompt: review_prompt,
                                      model: model, provider: provider)
             review_b = review_output(input: input, output: output_b, review_prompt: review_prompt,
@@ -73,7 +73,7 @@ module Legion
               review_a: review_a,
               review_b: review_b }
           rescue StandardError => e
-            log.warn(e.message) if respond_to?(:log, true)
+            log.warn(e.message) if respond_to?(:log, true) # rubocop:disable Legion/HelperMigration/LoggingGuard
             { reviewed: false, reason: "experiment error: #{e.message}" }
           end
 

--- a/lib/legion/extensions/eval/runners/annotation.rb
+++ b/lib/legion/extensions/eval/runners/annotation.rb
@@ -5,6 +5,8 @@ module Legion
     module Eval
       module Runners
         module Annotation
+          extend self
+
           def create_queue(name:, **opts)
             db[:annotation_queues].insert(
               name:                name,
@@ -15,7 +17,7 @@ module Legion
               created_at:          Time.now.utc
             )
             { created: true, name: name }
-          rescue Sequel::UniqueConstraintViolation
+          rescue Sequel::UniqueConstraintViolation => _e
             { error: 'already_exists', name: name }
           end
 

--- a/lib/legion/extensions/eval/runners/code_review.rb
+++ b/lib/legion/extensions/eval/runners/code_review.rb
@@ -13,7 +13,7 @@ module Legion
 
           SPEC_TIMEOUT = 30
 
-          def review_generated(code:, spec_code:, context:, review_k: nil, review_models: nil) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/MethodLength
+          def review_generated(code:, spec_code:, context: {}, review_k: nil, review_models: nil, **extra) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/ParameterLists, Metrics/PerceivedComplexity
             settings = validation_settings
             stages = {}
             issues = []
@@ -22,8 +22,9 @@ module Legion
             if settings[:syntax_check] != false
               stages[:syntax] = check_syntax(code, spec_code)
               unless stages[:syntax][:passed]
-                return build_result(passed: false, verdict: :reject, stages: stages,
-                                    issues: stages[:syntax][:errors], confidence: 0.0)
+                return build_result(passed: false, verdict: 'reject', stages: stages,
+                                    issues: stages[:syntax][:errors], confidence: 0.0,
+                                    code: code, spec_code: spec_code, extra: extra)
               end
             end
 
@@ -31,7 +32,8 @@ module Legion
             stages[:security] = check_security(code)
             unless stages[:security][:passed]
               issues.concat(stages[:security][:flagged].map { |f| "security: #{f[:pattern]} on line #{f[:line]}" })
-              return build_result(passed: false, verdict: :reject, stages: stages, issues: issues, confidence: 0.0)
+              return build_result(passed: false, verdict: 'reject', stages: stages, issues: issues, confidence: 0.0,
+                                  code: code, spec_code: spec_code, extra: extra)
             end
 
             # Stage 3: Spec execution (optional)
@@ -39,7 +41,8 @@ module Legion
               stages[:specs] = run_specs(code, spec_code)
               unless stages[:specs][:passed]
                 issues << "specs failed: #{stages[:specs][:output]}"
-                return build_result(passed: false, verdict: :revise, stages: stages, issues: issues, confidence: 0.2)
+                return build_result(passed: false, verdict: 'revise', stages: stages, issues: issues, confidence: 0.2,
+                                    code: code, spec_code: spec_code, extra: extra)
               end
             end
 
@@ -65,9 +68,10 @@ module Legion
             end
 
             confidence = calculate_confidence(stages)
-            verdict = confidence >= 0.5 ? :approve : :revise
+            verdict = confidence >= 0.5 ? 'approve' : 'revise'
 
-            build_result(passed: true, verdict: verdict, stages: stages, issues: issues, confidence: confidence)
+            build_result(passed: true, verdict: verdict, stages: stages, issues: issues, confidence: confidence,
+                         code: code, spec_code: spec_code, extra: extra)
           end
 
           private
@@ -282,8 +286,12 @@ module Legion
             scores
           end
 
-          def build_result(passed:, verdict:, stages:, issues:, confidence:)
-            { passed: passed, verdict: verdict, confidence: confidence, stages: stages, issues: issues }
+          def build_result(passed:, verdict:, stages:, issues:, confidence:, code: nil, spec_code: nil, extra: {}) # rubocop:disable Metrics/ParameterLists
+            result = { passed: passed, verdict: verdict, confidence: confidence, stages: stages, issues: issues }
+            result[:code] = code
+            result[:spec_code] = spec_code
+            extra.each { |k, v| result[k] = v unless result.key?(k) }
+            result
           end
         end
       end

--- a/lib/legion/extensions/eval/runners/code_review.rb
+++ b/lib/legion/extensions/eval/runners/code_review.rb
@@ -13,7 +13,7 @@ module Legion
 
           SPEC_TIMEOUT = 30
 
-          def review_generated(code:, spec_code:, context: {}, review_k: nil, review_models: nil, **extra) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/ParameterLists, Metrics/PerceivedComplexity
+          def review_generated(code:, spec_code:, context: {}, review_k: nil, review_models: nil, **extra) # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
             settings = validation_settings
             stages = {}
             issues = []
@@ -112,7 +112,7 @@ module Legion
             false
           end
 
-          def build_model_assignments(count, models) # rubocop:disable Metrics/PerceivedComplexity
+          def build_model_assignments(count, models)
             return Array.new(count) { nil } if models.nil? || models.empty?
 
             available = models.select do |spec|
@@ -132,7 +132,7 @@ module Legion
             Array.new(count) { |i| available[i % available.size] }
           end
 
-          def adversarial_llm_review(code, context, count:, models: []) # rubocop:disable Metrics/PerceivedComplexity
+          def adversarial_llm_review(code, context, count:, models: [])
             assignments = build_model_assignments(count, models)
 
             reviews = assignments.map { |spec| llm_review(code, context, model_spec: spec) }
@@ -205,7 +205,7 @@ module Legion
             { passed: false, output: '', errors: e.message, exit_code: -1 }
           end
 
-          def llm_review(code, context, model_spec: nil) # rubocop:disable Metrics/PerceivedComplexity
+          def llm_review(code, context, model_spec: nil)
             return { passed: true, issues: [], confidence: 0.5 } unless defined?(Runners::AgenticReview)
 
             extra_kwargs = {}
@@ -276,7 +276,7 @@ module Legion
             scores.sum / scores.size
           end
 
-          def stage_scores(stages) # rubocop:disable Metrics/PerceivedComplexity
+          def stage_scores(stages)
             scores = []
             scores << (stage_passed?(stages[:syntax]) ? 1.0 : 0.0) if stages[:syntax]
             scores << (stage_passed?(stages[:security]) ? 1.0 : 0.0) if stages[:security]
@@ -286,7 +286,7 @@ module Legion
             scores
           end
 
-          def build_result(passed:, verdict:, stages:, issues:, confidence:, code: nil, spec_code: nil, extra: {}) # rubocop:disable Metrics/ParameterLists
+          def build_result(passed:, verdict:, stages:, issues:, confidence:, code: nil, spec_code: nil, extra: {})
             result = { passed: passed, verdict: verdict, confidence: confidence, stages: stages, issues: issues }
             result[:code] = code
             result[:spec_code] = spec_code

--- a/lib/legion/extensions/eval/runners/evaluation.rb
+++ b/lib/legion/extensions/eval/runners/evaluation.rb
@@ -5,6 +5,8 @@ module Legion
     module Eval
       module Runners
         module Evaluation
+          extend self # rubocop:disable Style/ModuleFunction
+
           def run_evaluation(evaluator_name:, evaluator_config: {}, inputs: [], **)
             evaluator = build_evaluator(evaluator_name, evaluator_config)
             results = inputs.map.with_index do |row, idx|

--- a/lib/legion/extensions/eval/version.rb
+++ b/lib/legion/extensions/eval/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Eval
-      VERSION = '0.3.12'
+      VERSION = '0.3.13'
     end
   end
 end

--- a/lib/legion/extensions/eval/version.rb
+++ b/lib/legion/extensions/eval/version.rb
@@ -3,7 +3,7 @@
 module Legion
   module Extensions
     module Eval
-      VERSION = '0.3.11'
+      VERSION = '0.3.12'
     end
   end
 end

--- a/spec/legion/extensions/eval/runners/code_review_spec.rb
+++ b/spec/legion/extensions/eval/runners/code_review_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Legion::Extensions::Eval::Runners::CodeReview do
     it 'fails fast on syntax error' do
       result = described_class.review_generated(code: syntax_error_code, spec_code: '', context: {})
       expect(result[:passed]).to be false
-      expect(result[:verdict]).to eq(:reject)
+      expect(result[:verdict]).to eq('reject')
       expect(result[:stages][:syntax][:passed]).to be false
     end
 
@@ -58,7 +58,7 @@ RSpec.describe Legion::Extensions::Eval::Runners::CodeReview do
 
       result = described_class.review_generated(code: valid_code, spec_code: valid_spec, context: {})
       expect(result[:passed]).to be true
-      expect(result[:verdict]).to eq(:approve)
+      expect(result[:verdict]).to eq('approve')
       expect(result[:stages][:syntax][:passed]).to be true
       expect(result[:stages][:security][:passed]).to be true
     end


### PR DESCRIPTION
## Summary
- Add rubocop-legion 0.1.7 with shared lex.yml config profile
- Replace inline .rubocop.yml with inherit_gem directive
- Update CI workflow to use excluded-files check
- Fix all rubocop offenses

## Test plan
- [ ] CI passes (rspec + rubocop)